### PR TITLE
Add a switch to the widget to disable the top menu

### DIFF
--- a/html/schisto_gene.html
+++ b/html/schisto_gene.html
@@ -36,15 +36,14 @@
 <script src="/gxa/resources/js-bundles/vendorCommons.bundle.js"></script>
 <script src="/gxa/resources/js-bundles/heatmapHighcharts.bundle.js"></script>
 <script>
-    // http://www-test.ebi.ac.uk/gxa/json/baseline_experiments?species=homo+sapiens&geneQuery=[{"value":"zinc+finger"}]
     heatmapHighcharts.render(
         {
             target: 'highchartsContainer',
-            atlasUrl: 'http://localhost:8080/gxa/',
+            atlasUrl: 'https://www-test.ebi.ac.uk/gxa/',
+            showControlMenu: false,
             query: {
-                species: 'homo sapiens',
-                gene: [{value: 'zinc finger'}, {value: 'zinc'}],
-                condition: [{value: 'homo'}, {value: 'sapiens'}]
+                species: 'schistosoma mansoni',
+                gene: [{value: 'Smp_089700'}],
             }
         }
     );

--- a/src/Main.js
+++ b/src/Main.js
@@ -10,6 +10,7 @@ import ContainerLoader from './layout/ContainerLoader.js'
  * @param {Object}          options
  * @param {string | Object} options.target - a <div> id or a DOM element, as returned by ReactDOM.findDOMNode()
  * @param {boolean}         options.disableGoogleAnalytics - Disable Google Analytics
+ * @param {boolean}         options.showControlMenu - Show menu with sorting, filtering and download options
  * @param {function}        options.fail - Callback to run if the AJAX request to the server fails. (jqXHR, textStatus)
  * @param {function}        options.render - Callback to run after each render
  * @param {boolean}         options.showAnatomogram - optionally hide the anatomogram
@@ -30,6 +31,7 @@ const DEFAULT_OPTIONS = {
     showAnatomogram: true,
     isWidget: true,
     disableGoogleAnalytics: false,
+    showControlMenu: true,
     atlasUrl: `https://www.ebi.ac.uk/gxa/`,
     inProxy: ``,
     outProxy: ``,

--- a/src/load/chartConfiguration.js
+++ b/src/load/chartConfiguration.js
@@ -38,7 +38,7 @@ const singleExperimentQueryDescription = ({geneQuery, experiment:{description, a
     )
 }
 
-const getChartConfiguration = (data, inProxy, outProxy, atlasUrl, isWidget) => {
+const getChartConfiguration = (data, inProxy, outProxy, atlasUrl, isWidget, showControlMenu) => {
     const {experiment, profiles} = data
     const {geneQuery, conditionQuery, species, disclaimer, columnType, resources} = data.config
 
@@ -64,6 +64,7 @@ const getChartConfiguration = (data, inProxy, outProxy, atlasUrl, isWidget) => {
         atlasUrl,
         experiment,
         isWidget,
+        showControlMenu,
         description,
         shortDescription,
         disclaimer,

--- a/src/load/main.js
+++ b/src/load/main.js
@@ -9,7 +9,7 @@ import getColourAxisFromDataSeries from './heatmapColourAxis.js'
 import columnsWithGroupings from './heatmapFilters.js'
 import URI from 'urijs'
 
-export default function({data, inProxy, outProxy, atlasUrl, showAnatomogram, isWidget}) {
+export default function({data, inProxy, outProxy, atlasUrl, showAnatomogram, showControlMenu, isWidget}) {
     const pathToResources = inProxy + URI(`resources/js-bundles/`, atlasUrl).toString()
 
     // This ensures that adding or removing coexpressed genes doesn’t change the colours in the heat map. Colours are
@@ -46,7 +46,7 @@ export default function({data, inProxy, outProxy, atlasUrl, showAnatomogram, isW
         anatomogramConfig,
         heatmapData,
         geneSpecificResults,
-        heatmapConfig: getChartConfiguration(data, inProxy, outProxy, atlasUrl, isWidget),
+        heatmapConfig: getChartConfiguration(data, inProxy, outProxy, atlasUrl, isWidget, showControlMenu),
         colourAxis : getColourAxisFromDataSeries(data.experiment, heatmapData.dataSeries),
         orderings: createOrderingsForData(data.experiment, allRows, data.columnHeaders),
         columnGroups: columnsWithGroupings({heatmapData, columnGroupings: data.columnGroupings})

--- a/src/manipulate/HeatmapWithControls.js
+++ b/src/manipulate/HeatmapWithControls.js
@@ -240,12 +240,12 @@ const renderAnatomogramControlsAndCanvas = (args, heatmapDataToPresent, anatomog
             <div style={{display: `inline-block`, width: `30%`}}>
                 {args.heatmapConfig.introductoryMessage}
             </div>
-            <div style={{display: `inline-block`, width: `70%`, textAlign: `right`}}>
+            { args.heatmapConfig.showControlMenu && <div style={{display: `inline-block`, width: `70%`, textAlign: `right`}}>
                 {renderGenomeBrowsersDropdown(args)}
                 {renderOrderings(args)}
                 {renderFiltersButton(args)}
                 {renderDownloadButton(args,heatmapDataToPresent)}
-            </div>
+            </div> }
         </div>
         {
             renderGenomeBrowserHint(args)

--- a/src/manipulate/chartDataPropTypes.js
+++ b/src/manipulate/chartDataPropTypes.js
@@ -169,7 +169,7 @@ const heatmapConfigPropTypes = PropTypes.shape({
     yAxisLegendName: PropTypes.string.isRequired,
 
     experiment: experimentPropTypes,
-
+    showControlMenu: PropTypes.bool.isRequired,
     disclaimer: PropTypes.string.isRequired,
     coexpressionsAvailable: PropTypes.bool.isRequired,
     isMultiExperiment: PropTypes.bool.isRequired,


### PR DESCRIPTION
Hello! We've restored the Atlas widget in WBPS. It currently looks as follows:
[test page](http://test.parasite.wormbase.org/Schistosoma_mansoni_prjea36577/Gene/ExpressionAtlas?g=Smp_089700;r=Smp.Chr_1:2581013-2599719;t=Smp_089700.1). 

The top menu seems like it could be useful for other projects but it isn't really doing anything for us - I've made a fork of the Atlas widget and added a feature of disabling it. Would you merge this change? I think it's potentially useful across projects. 

I'd rather not maintain a fork long term if I can avoid it - if you don't like the switch as a feature would you consider adding a CSS class to the top menu - something like "gxaControlMenu" - so that we can style it with display:none?  