### PR TITLE
Bugfix #161648933 – Truncate very long gene names

### DIFF
--- a/src/manipulate/formatters/HeatmapCellTooltip.js
+++ b/src/manipulate/formatters/HeatmapCellTooltip.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 
 import ScientificNotationNumber from 'expression-atlas-number-format'
 
+import trimEllipsify from './trimEllipsify'
+
 const scientificNotation = value => <ScientificNotationNumber value={value} style={{fontWeight: `bold`}} />
 const roundTStat = (n) => (n ? +n.toFixed(4) : ``)
 
@@ -40,34 +42,19 @@ const yInfo = ({config, yLabel}) => _div(config.yAxisLegendName, yLabel)
 const xInfo = ({xAxisLegendName, config, xLabel}) => _div(xAxisLegendName || config.xAxisLegendName, xLabel)
 
 const tooltipValueMaxLength = 30
-const trimEllipsify = (str) => {
-  if (str.length > tooltipValueMaxLength) {
-    const words = str.slice(0, tooltipValueMaxLength).split(` `)
-    if (words.length > 1) {
-      return `${words.slice(0, -1).join(` `)}…`
-    } else {
-      return `${words[0].slice(0, -1)}…`
-    }
-  }
-
-  return str
-}
-
 const _comparisonDiv = (name, v1, v2, format) => {
   return (
     name && v1 && v2 ?
       <div key={`${name} ${v1} ${v2}`}>
         {`${name}: `}
         {v1.length + v2.length > tooltipValueMaxLength * 2 ? <br/> : null }
-        {(format || _bold)(trimEllipsify(v1))}
+        {(format || _bold)(trimEllipsify(v1, tooltipValueMaxLength))}
         <i style={{margin: `0.25rem`}}>vs</i>
-        {(format || _bold)(trimEllipsify(v2))}
+        {(format || _bold)(trimEllipsify(v2, tooltipValueMaxLength))}
       </div> :
       null
   )
 }
-
-
 
 const prettyName = (name) => (
   name

--- a/src/manipulate/formatters/axesFormatters.js
+++ b/src/manipulate/formatters/axesFormatters.js
@@ -10,7 +10,7 @@ const reactToHtml = component => escapedHtmlDecoder.decode(ReactDOMServer.render
 
 const YAxisLabel = (props) => {
   const geneNameWithLink =
-    <a href={props.config.outProxy + props.url}>
+    <a href={props.config.outProxy + props.url} style={{border: `none`, color: `#148ff3`}}>
       {trimEllipsify(props.labelText, 40)}
     </a>
 

--- a/src/manipulate/formatters/axesFormatters.js
+++ b/src/manipulate/formatters/axesFormatters.js
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types'
 import ReactDOMServer from 'react-dom/server'
 
 import escapedHtmlDecoder from 'he'
+
+import trimEllipsify from './trimEllipsify'
+
 const reactToHtml = component => escapedHtmlDecoder.decode(ReactDOMServer.renderToStaticMarkup(component))
 
 const YAxisLabel = (props) => {
   const geneNameWithLink =
     <a href={props.config.outProxy + props.url}>
-      {props.labelText}
+      {trimEllipsify(props.labelText, 40)}
     </a>
 
   return (
@@ -48,10 +51,10 @@ export default config => ({
 
   yAxisFormatter: value => reactToHtml(
     <YAxisLabel config={config}
-                labelText={value.label}
-                resourceId={value.id}
-                url={value.info.url}
-                extra={value.info.designElement || ``}
+      labelText={value.label}
+      resourceId={value.id}
+      url={value.info.url}
+      extra={value.info.designElement || ``}
     />
   ),
   yAxisStyle: {

--- a/src/manipulate/formatters/axesFormatters.js
+++ b/src/manipulate/formatters/axesFormatters.js
@@ -16,8 +16,12 @@ const YAxisLabel = (props) => {
 
   return (
     props.extra ?
-      <span>{geneNameWithLink}<em style={{color:`black`}}>{`\t${props.extra}`}</em></span> :
-      <span>{geneNameWithLink}</span>
+      <span title={props.labelText.length > 40 ? props.labelText : ``}>
+        {geneNameWithLink}<em style={{color:`black`}}>{`\t${props.extra}`}</em>
+      </span> :
+      <span title={props.labelText.length > 40 ? props.labelText : ``}>
+        {geneNameWithLink}
+      </span>
   )
 }
 

--- a/src/manipulate/formatters/trimEllipsify.js
+++ b/src/manipulate/formatters/trimEllipsify.js
@@ -1,0 +1,14 @@
+const trimEllipsify = (str, maxLength) => {
+  if (str.length > maxLength) {
+    const words = str.slice(0, maxLength).split(` `)
+    if (words.length > 1) {
+      return `${words.slice(0, -1).join(` `)} …`
+    } else {
+      return `${words[0].slice(0, -1)}…`
+    }
+  }
+
+  return str
+}
+
+export default trimEllipsify

--- a/src/show/HeatmapCanvas.js
+++ b/src/show/HeatmapCanvas.js
@@ -224,6 +224,7 @@ class HeatmapCanvas extends React.Component {
         useHTML: true,
         reversed: true,
         labels: {
+          useHTML: true,
           style: this.props.yAxisStyle,
           events: {
             mouseover: function() {


### PR DESCRIPTION
There will come a time when we’ll have tests and Travis reports, but so far this is the heatmap we need, not the heatmap we deserve.

To try it out, test E-GEOD-50777 on `ves-hx-76` in the experiment picker.