### PR TITLE
Tooltip truncates at bottom

### DIFF
--- a/src/show/HeatmapCanvas.js
+++ b/src/show/HeatmapCanvas.js
@@ -254,6 +254,7 @@ class HeatmapCanvas extends React.Component {
         shadow: false,
         enabled: true,
         backgroundColor: `none`,
+        outside: true,
         formatter: function() {
           return cellTooltipFormatter(this.series, this.point)
         }


### PR DESCRIPTION
I've used Highcharts config `outside: true` to avoid the issue. Link to Highchart doc regarding this config:
https://api.highcharts.com/highcharts/tooltip.outside

Signed-off-by: Haider Iqbal <haideri@ebi.ac.uk>