### PR TITLE
Fix genome browser url being redirect to same genome browser

### DIFF
--- a/src/manipulate/Events.js
+++ b/src/manipulate/Events.js
@@ -24,12 +24,12 @@ const _ontologyIdsForRowIndex = (heatmapData, y) => (
     .filter(onlyUnique)
 )
 
-const onClickUseGenomeBrowser = ({heatmapData, currentGenomeBrowser,heatmapConfig: {experiment, atlasUrl, outProxy}}) => (
-  currentGenomeBrowser && experiment && currentGenomeBrowser !== `none`
-    ? (x, y) => {
+const onClickUseGenomeBrowser = ({heatmapData, heatmapConfig: {experiment, atlasUrl, outProxy}}) => (
+  experiment ?
+    (x, y, genomeBrowser) => {
       window.open(outProxy + URI(experiment.urls.genome_browsers, atlasUrl).addSearch({
         experimentAccession: experiment.accession,
-        name: currentGenomeBrowser,
+        name: genomeBrowser,
         geneId: heatmapData.yAxisCategories[y].info.trackId,
         trackId: heatmapData.xAxisCategories[x].info.trackId
       }).toString(), `_blank`)
@@ -37,7 +37,7 @@ const onClickUseGenomeBrowser = ({heatmapData, currentGenomeBrowser,heatmapConfi
     : undefined
 )
 
-const makeEventCallbacks = ({heatmapData, onSelectOntologyIds, currentGenomeBrowser,heatmapConfig}) => {
+const makeEventCallbacks = ({heatmapData, onSelectOntologyIds, heatmapConfig}) => {
   return {
     onHoverRowLabel: (yAxisLabel) => {
       const rowIndex = heatmapData.yAxisCategories.findIndex((cat) => cat.label === sanitizeHtml(yAxisLabel, noTags))
@@ -57,7 +57,7 @@ const makeEventCallbacks = ({heatmapData, onSelectOntologyIds, currentGenomeBrow
       onSelectOntologyIds([])
     },
 
-    onClick: onClickUseGenomeBrowser({heatmapData, currentGenomeBrowser, heatmapConfig})
+    onClick: onClickUseGenomeBrowser({heatmapData, heatmapConfig})
   }
 }
 

--- a/src/manipulate/HeatmapWithControls.js
+++ b/src/manipulate/HeatmapWithControls.js
@@ -178,7 +178,6 @@ CanvasLegend.propTypes = {
 const heatmapExtraArgs = ({
   heatmapData,
   onOntologyIdIsUnderFocus,
-  currentGenomeBrowser,
   heatmapConfig,
   onChangeCurrentZoom,
   ontologyIdsToHighlight} ) => ({
@@ -189,7 +188,6 @@ const heatmapExtraArgs = ({
     makeEventCallbacks({
       heatmapData: heatmapData,
       onSelectOntologyIds: onOntologyIdIsUnderFocus,
-      currentGenomeBrowser,
       heatmapConfig}),
   cellTooltipFormatter: cellTooltipFormatter(heatmapConfig),
   ...axesFormatters(heatmapConfig)
@@ -230,7 +228,8 @@ const renderHeatmapCanvasWithSelectedDataSlice = (_args, heatmapDataToPresent, w
       <HeatmapCanvas
         {...heatmapExtraArgs(args)}
         heatmapData={heatmapDataToPresent}
-        withAnatomogram={withAnatomogram} />
+        withAnatomogram={withAnatomogram}
+        currentGenomeBrowser={_args.currentGenomeBrowser}/>
     </CanvasLegend>
   )
 }

--- a/src/show/HeatmapCanvas.js
+++ b/src/show/HeatmapCanvas.js
@@ -31,8 +31,8 @@ class HeatmapCanvas extends React.Component {
   shouldComponentUpdate(nextProps) {
     // Callback that does setState fails: https://github.com/kirjs/react-highcharts/issues/245
     // Don’t call render again after zoom happens
-    return hash.MD5([nextProps.heatmapData, nextProps.events.onClick, nextProps.withAnatomogram]) !==
-    hash.MD5([this.props.heatmapData, this.props.events.onClick, this.props.withAnatomogram])
+    return hash.MD5([nextProps.heatmapData, nextProps.events.onClick, nextProps.withAnatomogram, nextProps.currentGenomeBrowser]) !==
+    hash.MD5([this.props.heatmapData, this.props.events.onClick, this.props.withAnatomogram, this.props.currentGenomeBrowser])
   }
 
   _countColumns() {
@@ -117,7 +117,7 @@ class HeatmapCanvas extends React.Component {
     const marginRight = this._getAdjustedMarginRight()
     const height = this._getHeight(marginBottom)
 
-    const {cellTooltipFormatter, xAxisFormatter, yAxisFormatter, events, onZoom, noDataCellsColour} = this.props
+    const {cellTooltipFormatter, xAxisFormatter, yAxisFormatter, events, onZoom, noDataCellsColour, currentGenomeBrowser} = this.props
 
     const highchartsConfig = {
       chart: {
@@ -158,7 +158,7 @@ class HeatmapCanvas extends React.Component {
           cursor: events.onClick ? `pointer` : undefined,
           point: {
             events: {
-              click: events.onClick ? function() { events.onClick(this.x, this.y) } : function() {},
+              click: events.onClick ? function() { events.onClick(this.x, this.y, currentGenomeBrowser) } : function() {},
               mouseOver: function() { events.onHoverPoint(this.x) },
               mouseOut: function() { events.onHoverOff() }
             }
@@ -303,7 +303,8 @@ HeatmapCanvas.propTypes = {
     onClick: PropTypes.func
   }),
   onZoom: PropTypes.func.isRequired,
-  withAnatomogram: PropTypes.bool.isRequired
+  withAnatomogram: PropTypes.bool.isRequired,
+  currentGenomeBrowser: PropTypes.string.isRequired
 }
 
 HeatmapCanvas.defaultProps = {


### PR DESCRIPTION
The bug was when you change genome browser from the genome browser dropdown and click on heatmap cell it was being redirected to same default genome browser. Bug is further explained in this [pivotal story](https://www.pivotaltracker.com/story/show/168455605). 

To solve the bug I have passed the third parameter i.e. `currentGenomeBrowser` to `onClick` of heatmap cell.