### PR TITLE
Feature/180446075 change experiment type utils to allow Proteomics Baseline Dia Swath

### DIFF
--- a/src/load/experimentTypeUtils.js
+++ b/src/load/experimentTypeUtils.js
@@ -22,7 +22,7 @@ const isDifferential = experiment =>
   !isMultiExperiment(experiment) && experiment.type.toUpperCase().endsWith(`DIFFERENTIAL`)
 
 const isBaseline = experiment =>
-  !isMultiExperiment(experiment) && experiment.type.toUpperCase().endsWith(`BASELINE`)
+  !isMultiExperiment(experiment) && experiment.type.toUpperCase().contains(`BASELINE`)
 
 const isRnaSeqBaseline = experiment =>
   !isMultiExperiment(experiment) && experiment.type.toUpperCase() === `RNASEQ_MRNA_BASELINE`

--- a/src/load/experimentTypeUtils.js
+++ b/src/load/experimentTypeUtils.js
@@ -27,14 +27,4 @@ const isBaseline = experiment =>
 const isRnaSeqBaseline = experiment =>
   !isMultiExperiment(experiment) && experiment.type.toUpperCase() === `RNASEQ_MRNA_BASELINE`
 
-const getUnits = experiment => {
-  if (isDifferential(experiment)) {
-    return `Log2-fold change`  // What we use for point.value, we don't use it for display. See Formatters.jsx.
-  } else if (isRnaSeqBaseline(experiment)) {
-    return experiment.description.toUpperCase().includes(`FANTOM`) ? `TPM` : `FPKM`
-  } else {
-    return ``
-  }
-}
-
-export {experimentPropTypes, isMultiExperiment, isDifferential, isBaseline, isRnaSeqBaseline, getUnits}
+export {experimentPropTypes, isMultiExperiment, isDifferential, isBaseline, isRnaSeqBaseline}

--- a/src/load/experimentTypeUtils.js
+++ b/src/load/experimentTypeUtils.js
@@ -22,7 +22,7 @@ const isDifferential = experiment =>
   !isMultiExperiment(experiment) && experiment.type.toUpperCase().endsWith(`DIFFERENTIAL`)
 
 const isBaseline = experiment =>
-  !isMultiExperiment(experiment) && experiment.type.toUpperCase().contains(`BASELINE`)
+  !isMultiExperiment(experiment) && experiment.type.toUpperCase().includes(`BASELINE`)
 
 const isRnaSeqBaseline = experiment =>
   !isMultiExperiment(experiment) && experiment.type.toUpperCase() === `RNASEQ_MRNA_BASELINE`


### PR DESCRIPTION
Existing codebase:

```
const isBaseline = experiment =>
  !isMultiExperiment(experiment) && experiment.type.toUpperCase().endsWith(`BASELINE`)
```
The above codebase doesn't work for the experiment type "PROTEOMICS_BASELINE_DIA_SWATH" as it's not ending with BASELINE.

So, this PR accommodates both experiment types: `Proteomics Baseline` and `Proteomics Baseline Dia Swath`.