### PR TITLE
Bugfix #180540094 – Fix download behaviour

### DIFF
--- a/src/layout/Container.js
+++ b/src/layout/Container.js
@@ -13,9 +13,6 @@ import loadChartData from '../load/main.js'
 const Container = (props) => {
   const {data, outProxy, atlasUrl, isWidget} = props
   const {geneQuery, conditionQuery, species} = data.config
-  //make a geneID list for download button and not include category due to missing information but it will still work
-  const geneQueryIDList = data.profiles.rows.map(gene => ({"value":gene.name}));
-
 
   const moreInformationUrl = data.experiment ?    // single experiment?
     URI(data.experiment.urls.main_page, atlasUrl) :
@@ -30,8 +27,7 @@ const Container = (props) => {
         description={data.experiment.description} /> }
 
       <ChartContainer
-        chartData={loadChartData(props)}
-        geneQueryIDList={geneQueryIDList} />
+        chartData={loadChartData(props)} />
 
       { isWidget &&
       <Footer

--- a/src/load/chartConfiguration.js
+++ b/src/load/chartConfiguration.js
@@ -6,8 +6,11 @@ const introductoryMessage = (experiment, profiles) => {
   const shownRows = profiles.rows.length
   const totalRows = +(profiles.searchResultTotal || shownRows)
 
-  const what = (experiment ? experiment.type === `proteomics_differential` || `proteomics_baseline` ?
-                  `protein` : `gene` : `experiment`) + (totalRows > 1 ? `s` : ``)
+  const what =
+    (experiment ?
+      (experiment.type.toUpperCase().includes(`PROTEOMICS`)  ? `protein` : `gene`) :
+      `experiment`)
+    + (totalRows > 1 ? `s` : ``)
 
   return shownRows > 0 ?
     `Showing ${numberWithCommas(shownRows)} ` +

--- a/src/manipulate/ChartContainer.js
+++ b/src/manipulate/ChartContainer.js
@@ -33,7 +33,7 @@ class ChartContainer extends React.Component {
         </a>
         }
         <div style={{display: this.state.chartType === `heatmap` ? `block` : `none`, width: `100%`}} >
-          <Heatmap {...this.props.chartData} geneQueryIDList={this.props.geneQueryIDList} />
+          <Heatmap {...this.props.chartData} />
         </div>
         { this.props.chartData.geneSpecificResults &&
         <div style={{display: this.state.chartType === `boxplot and transcripts` ? `block` : `none`, width: `100%`}} >

--- a/src/manipulate/HeatmapWithControls.js
+++ b/src/manipulate/HeatmapWithControls.js
@@ -84,8 +84,7 @@ const renderDownloadButton = ({
   },
   currentOrdering,
   allNumCoexpressions,
-  currentNumCoexpressions,
-  geneQueryIDList}
+  currentNumCoexpressions}
 ,heatmapData) => (
   <div style={{display: `inline-block`, padding: `5px`}}>
     <DownloadButton
@@ -105,7 +104,7 @@ const renderDownloadButton = ({
           ? outProxy+URI(experiment.urls.download, atlasUrl).toString()
           : ``
       }
-      geneQueryIDList= {geneQueryIDList} />
+    />
   </div>
 )
 

--- a/src/manipulate/controls/download-button/Download.js
+++ b/src/manipulate/controls/download-button/Download.js
@@ -1,11 +1,11 @@
 import _range from 'lodash/range'
 import download from 'downloadjs'
 
-const heatmapDataIntoLinesOfData = (heatmapData) => {
+const heatmapDataIntoLinesOfData = (heatmapData, placeholder) => {
 
   const heatmapDataAsMatrix =
     _range(heatmapData.yAxisCategories.length)
-      .map(y => _range(heatmapData.xAxisCategories.length).map(x => `NA`))
+      .map(() => _range(heatmapData.xAxisCategories.length).map(() => placeholder))
 
   heatmapData.dataSeries.forEach(series => {
     series.data.forEach(point => {heatmapDataAsMatrix[point.y][point.x] = point.value})
@@ -20,14 +20,14 @@ const heatmapDataIntoLinesOfData = (heatmapData) => {
 
 }
 
-const CommenceDownload = ({name, descriptionLines, heatmapData}) => {
+const CommenceDownload = ({name, descriptionLines, heatmapData, isSingleExperiment}) => {
   download(
     new Blob(
       [
         `# Downloaded from: ${window.location.href}`,
         `# Timestamp: ${new Date().toISOString()}`,
         ...descriptionLines.map(line => `# ${line}`),
-        ...heatmapDataIntoLinesOfData(heatmapData)
+        ...heatmapDataIntoLinesOfData(heatmapData, isSingleExperiment ? `` : `NA`)
       ].map(line => `${line}\n`)
     ),
     `${name.replace(/ +/, `_`)}.tsv`,

--- a/src/manipulate/controls/download-button/DownloadButton.js
+++ b/src/manipulate/controls/download-button/DownloadButton.js
@@ -87,25 +87,23 @@ const SplitDownloadButton = ({downloadOptions}) => (
 )
 
 
-const DownloadButton = ({currentlyShownContent, geneQueryIDList, fullDatasetUrl, disclaimer}) => {
-  const allDataDownloadUrl = new URI(fullDatasetUrl)
-  //set cutoff as 0.0 to get all available data in the download file
-  allDataDownloadUrl.setSearch({cutoff:`0.0`,geneQuery:JSON.stringify(geneQueryIDList)}).removeSearch(`heatmapMatrixSize`)
-
+const DownloadButton = ({currentlyShownContent, fullDatasetUrl, disclaimer}) => {
   const downloadOptions = [].concat(
     fullDatasetUrl ?
       [{
-        onClick: () => window.open(allDataDownloadUrl.toString(), `Download`),
+        onClick: () =>
+          window.open(
+            new URI(fullDatasetUrl).setSearch({cutoff: `0.0`}).removeSearch(`heatmapMatrixSize`).toString(),
+            `Download`),
         description: `All data`
       }] :
       [],
     [{
-      onClick: () => fullDatasetUrl ?
-        window.open(fullDatasetUrl, `Download`) :
-        ClientSideDownload(currentlyShownContent),
+      onClick: () => ClientSideDownload({...currentlyShownContent, isSingleExperiment: Boolean(fullDatasetUrl)}),
       description : `Table content`
     }]
   )
+
   return (
     disclaimers[disclaimer] ?
       <DownloadWithModal


### PR DESCRIPTION
Rather than take the list of gene IDs from the heatmap and use them in a more sophisticated query, “Download - Table content” produces *exactly* what the user is seeing in the table.

I simplified here also the logic to choose between genes and proteins for the “Showing ...”  header and added an optional placeholder for the multiexperiment heatmap, since missing factors/characteristics are now a reality.